### PR TITLE
bugfix

### DIFF
--- a/MrCode/Sections/Repositories/RepositoriesTableVC.m
+++ b/MrCode/Sections/Repositories/RepositoriesTableVC.m
@@ -538,7 +538,10 @@ static NSString *kCustomReposCellIdentifier = @"CustomReposCellIdentifier";
         // 滚到最顶部
         _needScrollToTop = NO;
         NSIndexPath *indexPath = [NSIndexPath indexPathForRow:0 inSection:0];
-        [self.tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionTop animated:YES];
+        if ([self.tableView cellForRowAtIndexPath:indexPath]) { // check nil
+                    [self.tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionTop animated:YES];
+        }
+
     }
 }
 


### PR DESCRIPTION
修复Repositories标签下当Starred为零时切换顶部segment闪退的bug

console：
Terminating app due to uncaught exception 'NSRangeException', reason:
'-[UITableView
_contentOffsetForScrollingToRowAtIndexPath:atScrollPosition:]: row (0)
beyond bounds (0) for section (0).'
